### PR TITLE
Fixed 500 when work package custom field of type user or version exist.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+* `#3216` Fix: Reporting creates 500 when a CustomField with content type version or user exists
 * `#4024` Subpages have no unique page titles
 
 ## 4.0.0.pre9

--- a/app/models/cost_query/custom_field_mixin.rb
+++ b/app/models/cost_query/custom_field_mixin.rb
@@ -25,7 +25,7 @@ module CostQuery::CustomFieldMixin
   end
 
   def generate_subclasses
-    WorkPackageCustomField.all.map do |field|
+    WorkPackageCustomField.all(:conditions => "field_format in ('#{SQL_TYPES.keys.join('\',\'')}')").map do |field|
       class_name = "CustomField#{field.id}"
       parent.send(:remove_const, class_name) if parent.const_defined? class_name
       parent.const_set class_name, Class.new(self)


### PR DESCRIPTION
This fix disabled filtering for these fields (intended, as this would not
work the normal custom fields way) but also grouping by these custom
fields (not really intended, but due to the DRY structure of the code
and not enough time for a clean rewrite and also no interest to add
yet another hack)

Implements https://www.openproject.org/work_packages/3216
