### PR TITLE
Fix save unit types

### DIFF
--- a/app/controllers/cost_reports_controller.rb
+++ b/app/controllers/cost_reports_controller.rb
@@ -165,7 +165,7 @@ class CostReportsController < ApplicationController
     @unit_id = 0 unless @cost_types.include? @unit_id
   end
 
-  # Determine the active cost type, if it is not labor or money, and add a hidden filter to the query
+  # Determine the active cost type and add a hidden filter to the query
   #   sets the @cost_type -> this is used to select the proper units for display
   def set_cost_type
     if @query

--- a/app/controllers/cost_reports_controller.rb
+++ b/app/controllers/cost_reports_controller.rb
@@ -168,7 +168,7 @@ class CostReportsController < ApplicationController
   # Determine the active cost type, if it is not labor or money, and add a hidden filter to the query
   #   sets the @cost_type -> this is used to select the proper units for display
   def set_cost_type
-    if @unit_id != 0 && @query
+    if @query
       @query.filter :cost_type_id, operator: '=', value: @unit_id.to_s, display: false
       @cost_type = CostType.find(@unit_id) if @unit_id > 0
     end

--- a/app/controllers/cost_reports_controller.rb
+++ b/app/controllers/cost_reports_controller.rb
@@ -169,6 +169,10 @@ class CostReportsController < ApplicationController
   #   sets the @cost_type -> this is used to select the proper units for display
   def set_cost_type
     if @query
+      existing_filter = @query.filters.detect { |f| f.is_a?(CostQuery::Filter::CostTypeId) }
+      if existing_filter
+        @query.remove_filter(existing_filter)
+      end
       @query.filter :cost_type_id, operator: '=', value: @unit_id.to_s, display: false
       @cost_type = CostType.find(@unit_id) if @unit_id > 0
     end

--- a/spec/models/cost_query/chaining_spec.rb
+++ b/spec/models/cost_query/chaining_spec.rb
@@ -1,7 +1,7 @@
 #-- copyright
 # OpenProject Reporting Plugin
 #
-# Copyright (C) 2010 - 2014 the OpenProject Foundation (OPF)
+# Copyright (C) 2010 - 2015 the OpenProject Foundation (OPF)
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -314,6 +314,38 @@ describe CostQuery, type: :model, reporting_query_helper: true do
         end
         expect(TestFilter.selectable?).to be true
         Object.send(:remove_const, :TestFilter)
+      end
+    end
+
+    describe '#remove' do
+      before do
+        @chain = Report::Chainable.new
+        @chain = Report::Chainable.new(@chain)
+      end
+
+      it 'has one less element after removal' do
+        count_before = @chain.count
+        @chain = @chain.remove(@chain.bottom)
+        expect(@chain.count).to eq(count_before - 1)
+      end
+
+      it 'removes the specified element' do
+        @chain = @chain.remove(@chain.bottom)
+        expect(@chain.top).to eq(@chain.bottom)
+      end
+
+      it 'returns the top of the chain' do
+        @chain = Report::Chainable.new(@chain)
+        chain_top = @chain.top
+        @chain = @chain.remove(@chain.top.child)
+        expect(chain_top).to eq(@chain.top)
+      end
+
+      it 'properly disconnects the removed element from the chain' do
+        @chain = Report::Chainable.new(@chain)
+        @chain = @chain.remove(@chain.top.child)
+        expect(@chain.top.child).to eq(@chain.bottom)
+        expect(@chain.bottom.parent).to eq(@chain.top)
       end
     end
   end


### PR DESCRIPTION
This should prevent invalid filter queries to be created, i.e. cash value filters no longer just work because cash value is the default type.

https://community.openproject.org/work_packages/17166
