### PR TITLE
Remove core time entries top menu item

### DIFF
--- a/lib/open_project/reporting/engine.rb
+++ b/lib/open_project/reporting/engine.rb
@@ -55,6 +55,11 @@ module OpenProject::Reporting
         )
       }
 
+    # Cost reports should replace the default time entries menu item
+    Redmine::MenuManager.map(:top_menu) do |menu|
+      menu.delete(:time_sheet)
+    end
+
     menu :project_menu, :cost_reports,
          {controller: 'cost_reports', action: 'index'},
          param: :project_id,


### PR DESCRIPTION
When this plugin is loaded, Cost Reports should replace the default
menu item 'Modules' > 'Time Entries'.
This commit removes the time entries menu item.

Relevant work package:
https://community.openproject.org/work_packages/20269
