### PR TITLE
Remove core time entries top menu item

### DIFF
--- a/lib/open_project/reporting/engine.rb
+++ b/lib/open_project/reporting/engine.rb
@@ -63,9 +63,13 @@ module OpenProject::Reporting
            if: Proc.new { |project| project.module_enabled?(:reporting_module) },
            html: { class: 'icon2 icon-stats' }
 
+      # Cost reports should remove the default time entries menu item
       hide_menu_item :project_menu,
                      :time_entries,
                      hide_if: -> (project) { project.module_enabled?(:reporting_module) }
+
+      hide_menu_item :top_menu,
+                     :time_sheet
     end
 
     initializer "reporting.register_hooks" do


### PR DESCRIPTION
When this plugin is loaded, Cost Reports should replace the default
menu item 'Modules' > 'Time Entries'.
This commit removes the time entries menu item.

Relevant work package:
https://community.openproject.org/work_packages/20269
