### PR TITLE
Feature/threadsafe custom field filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ from your `Gemfile.plugins` in your OpenProject installation folder and run:
 to uninstall the ReportingEngine and the OpenProject Reporting plugin.
 
 
+Configuration
+-------------
+
+* `cost_reporting_cache_filter_classes: true`
+
+OpenProject Reporting, when not configured otherwise, optimizes response time by caching the filters and group by options generated for work package custom fields. Only when the custom fields are invalidated, does reporting recreate the elements by information from the database. In some scenarios, such a behavior might not be desirable. Especially, when databases are switched between requests to serve information from another installation, caching will almost always fail as the information is outdated and in some edge cases, filters and group by options are displayed erroneously. In such a setting, it is advisible to deactivate the caching by setting `cost_reporting_cache_filter_classes` to `false` in OpenProject's `config/configuration.yml`
+
+
 Bug Reporting
 -------------
 

--- a/app/controllers/cost_reports_controller.rb
+++ b/app/controllers/cost_reports_controller.rb
@@ -46,29 +46,12 @@ class CostReportsController < ApplicationController
   helper_method :private_queries
 
   attr_accessor :cost_types, :unit_id, :cost_type
-  cattr_accessor :custom_fields_updated_on, :custom_fields_id_sum
 
   # Checks if custom fields have been updated, added or removed since we
   # last saw them, to rebuild the filters and group bys.
   # Called once per request.
-  def check_cache(force_update = false)
-    custom_fields_updated_on = WorkPackageCustomField.maximum(:updated_at)
-    custom_fields_id_sum = WorkPackageCustomField.sum(:id) + WorkPackageCustomField.count
-
-    if force_update or (custom_fields_updated_on && custom_fields_id_sum)
-      if force_update or (
-          self.class.custom_fields_updated_on != custom_fields_updated_on ||
-          self.class.custom_fields_id_sum != custom_fields_id_sum)
-
-        self.class.custom_fields_updated_on = custom_fields_updated_on
-        self.class.custom_fields_id_sum = custom_fields_id_sum
-
-        CostQuery::Filter.reset!
-        CostQuery::Filter::CustomFieldEntries.reset!
-        CostQuery::GroupBy.reset!
-        CostQuery::GroupBy::CustomFieldEntries.reset!
-      end
-    end
+  def check_cache
+    CostQuery::Cache.check
   end
 
   ##

--- a/app/models/cost_query/cache.rb
+++ b/app/models/cost_query/cache.rb
@@ -1,0 +1,65 @@
+#-- copyright
+# OpenProject Reporting Plugin
+#
+# Copyright (C) 2010 - 2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#++
+
+module CostQuery::Cache
+  class << self
+
+    def check
+      reset! if invalid?
+    end
+
+    def reset!
+      CostQuery::Filter.reset!
+      CostQuery::Filter::CustomFieldEntries.reset!
+      CostQuery::GroupBy.reset!
+      CostQuery::GroupBy::CustomFieldEntries.reset!
+
+      update_reset_on
+    end
+
+    protected
+
+    attr_accessor :custom_fields_updated_on,
+                  :custom_fields_id_sum
+
+    def invalid?
+      updated_on = fetch_custom_field_updated_at
+      id_sum = fetch_custom_fields_changed
+
+      custom_fields_exist = updated_on && id_sum
+      custom_fields_changed = custom_fields_updated_on != updated_on ||
+                                custom_fields_id_sum != id_sum
+
+      custom_fields_exist && custom_fields_changed
+    end
+
+    def update_reset_on
+      self.custom_fields_updated_on = fetch_custom_field_updated_at
+      self.custom_fields_id_sum = fetch_custom_fields_changed
+    end
+
+    def fetch_custom_field_updated_at
+      WorkPackageCustomField.maximum(:updated_at)
+    end
+
+    def fetch_custom_fields_changed
+      WorkPackageCustomField.sum(:id) + WorkPackageCustomField.count
+    end
+  end
+end

--- a/app/models/cost_query/cache.rb
+++ b/app/models/cost_query/cache.rb
@@ -25,40 +25,40 @@ module CostQuery::Cache
     end
 
     def reset!
+      update_reset_on
+
       CostQuery::Filter.reset!
       CostQuery::Filter::CustomFieldEntries.reset!
       CostQuery::GroupBy.reset!
       CostQuery::GroupBy::CustomFieldEntries.reset!
-
-      update_reset_on
     end
 
     protected
 
-    attr_accessor :custom_fields_updated_on,
-                  :custom_fields_id_sum
+    attr_accessor :latest_custom_field_change,
+                  :custom_field_count
 
     def invalid?
-      updated_on = fetch_custom_field_updated_at
-      id_sum = fetch_custom_fields_changed
+      changed_on = fetch_latest_custom_field_change
+      field_count = fetch_current_custom_field_count
 
-      custom_fields_updated_on != updated_on ||
-        custom_fields_id_sum != id_sum
+      latest_custom_field_change != changed_on ||
+        custom_field_count != field_count
     end
 
     def update_reset_on
       return if caching_disabled?
 
-      self.custom_fields_updated_on = fetch_custom_field_updated_at
-      self.custom_fields_id_sum = fetch_custom_fields_changed
+      self.latest_custom_field_change = fetch_latest_custom_field_change
+      self.custom_field_count = fetch_current_custom_field_count
     end
 
-    def fetch_custom_field_updated_at
+    def fetch_latest_custom_field_change
       WorkPackageCustomField.maximum(:updated_at)
     end
 
-    def fetch_custom_fields_changed
-      WorkPackageCustomField.sum(:id) + WorkPackageCustomField.count
+    def fetch_current_custom_field_count
+      WorkPackageCustomField.count
     end
 
     def caching_disabled?
@@ -71,5 +71,5 @@ module CostQuery::Cache
   end
 
   # initialize to 0 to avoid forced cache reset on first request
-  self.custom_fields_id_sum = 0
+  self.custom_field_count = 0
 end

--- a/app/models/cost_query/cache.rb
+++ b/app/models/cost_query/cache.rb
@@ -21,7 +21,7 @@ module CostQuery::Cache
   class << self
 
     def check
-      reset! if invalid?
+      reset! if reset_required?
     end
 
     def reset!
@@ -47,6 +47,8 @@ module CostQuery::Cache
     end
 
     def update_reset_on
+      return if caching_disabled?
+
       self.custom_fields_updated_on = fetch_custom_field_updated_at
       self.custom_fields_id_sum = fetch_custom_fields_changed
     end
@@ -57,6 +59,14 @@ module CostQuery::Cache
 
     def fetch_custom_fields_changed
       WorkPackageCustomField.sum(:id) + WorkPackageCustomField.count
+    end
+
+    def caching_disabled?
+      !OpenProject::Configuration.cost_reporting_cache_filter_classes
+    end
+
+    def reset_required?
+      caching_disabled? || invalid?
     end
   end
 

--- a/app/models/cost_query/cache.rb
+++ b/app/models/cost_query/cache.rb
@@ -42,11 +42,8 @@ module CostQuery::Cache
       updated_on = fetch_custom_field_updated_at
       id_sum = fetch_custom_fields_changed
 
-      custom_fields_exist = updated_on && id_sum
-      custom_fields_changed = custom_fields_updated_on != updated_on ||
-                                custom_fields_id_sum != id_sum
-
-      custom_fields_exist && custom_fields_changed
+      custom_fields_updated_on != updated_on ||
+        custom_fields_id_sum != id_sum
     end
 
     def update_reset_on
@@ -62,4 +59,7 @@ module CostQuery::Cache
       WorkPackageCustomField.sum(:id) + WorkPackageCustomField.count
     end
   end
+
+  # initialize to 0 to avoid forced cache reset on first request
+  self.custom_fields_id_sum = 0
 end

--- a/app/models/cost_query/custom_field_mixin.rb
+++ b/app/models/cost_query/custom_field_mixin.rb
@@ -27,7 +27,8 @@ module CostQuery::CustomFieldMixin
     'text'   => mysql? ? 'char' : 'text',
     'bool'   => mysql? ? 'unsigned' : 'boolean',
     'date'  => 'date',
-    'int'   => 'decimal(60,3)', 'float' => 'decimal(60,3)' }
+    'int'   => 'decimal(60,3)',
+    'float' => 'decimal(60,3)' }
 
   def self.extended(base)
     base.inherited_attribute :factory

--- a/app/models/cost_query/custom_field_mixin.rb
+++ b/app/models/cost_query/custom_field_mixin.rb
@@ -42,6 +42,8 @@ module CostQuery::CustomFieldMixin
 
   def reset!
     @all = nil
+
+    remove_subclasses
   end
 
   def generate_subclasses
@@ -50,6 +52,14 @@ module CostQuery::CustomFieldMixin
       parent.send(:remove_const, class_name) if parent.const_defined? class_name
       parent.const_set class_name, Class.new(self)
       parent.const_get(class_name).prepare(field, class_name)
+    end
+  end
+
+  def remove_subclasses
+    parent.constants.each do |constant|
+      if constant.to_s.match /^CustomField\d+/
+        parent.send(:remove_const, constant)
+      end
     end
   end
 

--- a/lib/open_project/reporting/engine.rb
+++ b/lib/open_project/reporting/engine.rb
@@ -90,6 +90,9 @@ module OpenProject::Reporting
       require_dependency 'cost_query/group_by'
     end
 
-    patches [:CostlogController, :TimelogController, :CustomFieldsController]
+    patches [:CostlogController,
+             :TimelogController,
+             :CustomFieldsController,
+             :'OpenProject::Configuration']
   end
 end

--- a/lib/open_project/reporting/patches/open_project/configuration_patch.rb
+++ b/lib/open_project/reporting/patches/open_project/configuration_patch.rb
@@ -1,0 +1,31 @@
+#-- copyright
+# OpenProject Reporting Plugin
+#
+# Copyright (C) 2010 - 2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#++
+
+
+require_dependency 'open_project/configuration'
+
+module OpenProject::Reporting::Patches
+  module OpenProject::ConfigurationPatch
+    def self.included(base)
+      base.class_eval do
+        @defaults['cost_reporting_cache_filter_classes'] = true
+      end
+    end
+  end
+end

--- a/spec/lib/open_project/configuration_spec.rb
+++ b/spec/lib/open_project/configuration_spec.rb
@@ -1,0 +1,47 @@
+#-- copyright
+# OpenProject Reporting Plugin
+#
+# Copyright (C) 2010 - 2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#++
+
+require 'spec_helper'
+
+describe 'OpenProject::Configuration' do
+  context '.cost_reporting_cache_filter_classes' do
+    before do
+      # This prevents the values from the actual configuration file to influence
+      # the test outcome.
+      #
+      # TODO: I propose to port this over to the core to always prevent this for specs.
+      OpenProject::Configuration.load(file: 'bogus')
+    end
+
+    after do
+      # resetting for now to avoid braking specs, who by now rely on having the file read.
+      OpenProject::Configuration.load
+    end
+
+    it 'is a true by default via the method' do
+      expect(OpenProject::Configuration.cost_reporting_cache_filter_classes).to be_truthy
+    end
+
+
+    it 'is true by default via the hash' do
+      expect(OpenProject::Configuration['cost_reporting_cache_filter_classes']).to be_truthy
+    end
+
+  end
+end

--- a/spec/models/cost_query/cache_spec.rb
+++ b/spec/models/cost_query/cache_spec.rb
@@ -44,19 +44,17 @@ describe CostQuery::Cache do
 
   def reset_cache_keys
     # resetting internal caching keys to avoid dependencies with other specs
-    described_class.send(:custom_fields_updated_on=, nil)
-    described_class.send(:custom_fields_id_sum=, 0)
+    described_class.send(:latest_custom_field_change=, nil)
+    described_class.send(:custom_field_count=, 0)
   end
 
   def custom_fields_exist
     allow(WorkPackageCustomField).to receive(:maximum).and_return(Time.now)
-    allow(WorkPackageCustomField).to receive(:sum).and_return(42)
     allow(WorkPackageCustomField).to receive(:count).and_return(23)
   end
 
   def no_custom_fields_exist
     allow(WorkPackageCustomField).to receive(:maximum).and_return(nil)
-    allow(WorkPackageCustomField).to receive(:sum).and_return(0)
     allow(WorkPackageCustomField).to receive(:count).and_return(0)
   end
 

--- a/spec/models/cost_query/filter_spec.rb
+++ b/spec/models/cost_query/filter_spec.rb
@@ -329,7 +329,7 @@ describe CostQuery, type: :model, reporting_query_helper: true do
       end
 
       def clear_cache
-        CostReportsController.new.check_cache(true)
+        CostQuery::Cache.reset!
         CostQuery::Filter::CustomFieldEntries.all
       end
 

--- a/spec/models/cost_query/filter_spec.rb
+++ b/spec/models/cost_query/filter_spec.rb
@@ -324,6 +324,12 @@ describe CostQuery, type: :model, reporting_query_helper: true do
         cf
       end
 
+      let(:custom_field2) do
+        FactoryGirl.build(:work_package_custom_field, name: 'Database',
+                                                      field_format: "list",
+                                                      possible_values: ['value'])
+      end
+
       after(:all) do
         clear_cache
       end
@@ -333,8 +339,8 @@ describe CostQuery, type: :model, reporting_query_helper: true do
         CostQuery::Filter::CustomFieldEntries.all
       end
 
-      def delete_work_package_custom_field(name)
-        WorkPackageCustomField.find_by_name(name).destroy
+      def delete_work_package_custom_field(cf)
+        cf.destroy
         clear_cache
       end
 
@@ -345,44 +351,42 @@ describe CostQuery, type: :model, reporting_query_helper: true do
         clear_cache
       end
 
-      def class_name_for(name)
-        "CostQuery::Filter::CustomField#{WorkPackageCustomField.find_by_name(name).id}"
+      def class_name_for(cf)
+        "CostQuery::Filter::CustomField#{cf.id}"
       end
 
       it "should create classes for custom fields that get added after starting the server" do
         custom_field
-        expect { class_name_for('My custom field').constantize }.not_to raise_error
+        expect { class_name_for(custom_field).constantize }.not_to raise_error
       end
 
       it "should remove the custom field classes after it is deleted" do
         custom_field
-        class_name = class_name_for('My custom field')
-        delete_work_package_custom_field("My custom field")
-        expect(CostQuery::Filter.all).not_to include class_name.constantize
+        class_name = class_name_for(custom_field)
+        delete_work_package_custom_field(custom_field)
+        expect { class_name_for(custom_field).constantize }.to raise_error NameError
       end
 
       it "should provide the correct available values" do
-        FactoryGirl.create(:work_package_custom_field, name: 'Database',
-                                                field_format: "list",
-                                                possible_values: ['value'])
+        custom_field2.save
+
         clear_cache
-        ao = class_name_for('Database').constantize.available_operators.map(&:name)
+        ao = class_name_for(custom_field2).constantize.available_operators.map(&:name)
         CostQuery::Operator.null_operators.each do |o|
           expect(ao).to include o.name
         end
       end
 
       it "should update the available values on change" do
-        FactoryGirl.create(:work_package_custom_field, name: 'Database',
-                                                field_format: "list",
-                                                possible_values: ['value'])
+        custom_field2.save
+
         update_work_package_custom_field("Database", field_format: "string")
-        ao = class_name_for('Database').constantize.available_operators.map(&:name)
+        ao = class_name_for(custom_field2).constantize.available_operators.map(&:name)
         CostQuery::Operator.string_operators.each do |o|
           expect(ao).to include o.name
         end
         update_work_package_custom_field("Database", field_format: "int")
-        ao = class_name_for('Database').constantize.available_operators.map(&:name)
+        ao = class_name_for(custom_field2).constantize.available_operators.map(&:name)
         CostQuery::Operator.integer_operators.each do |o|
           expect(ao).to include o.name
         end
@@ -391,13 +395,13 @@ describe CostQuery, type: :model, reporting_query_helper: true do
       it "includes custom fields classes in CustomFieldEntries.all" do
         custom_field
         expect(CostQuery::Filter::CustomFieldEntries.all).
-          to include(class_name_for('My custom field').constantize)
+          to include(class_name_for(custom_field).constantize)
       end
 
       it "includes custom fields classes in Filter.all" do
         custom_field
         expect(CostQuery::Filter.all).
-          to include(class_name_for('My custom field').constantize)
+          to include(class_name_for(custom_field).constantize)
       end
 
       def create_searchable_fields_and_values

--- a/spec/models/cost_query/filter_spec.rb
+++ b/spec/models/cost_query/filter_spec.rb
@@ -18,6 +18,7 @@
 #++
 
 require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
+require File.join(File.dirname(__FILE__), '..', '..', 'support', 'custom_field_filter')
 
 describe CostQuery, type: :model, reporting_query_helper: true do
   minimal_query
@@ -351,27 +352,25 @@ describe CostQuery, type: :model, reporting_query_helper: true do
         clear_cache
       end
 
-      def class_name_for(cf)
-        "CostQuery::Filter::CustomField#{cf.id}"
-      end
+      include OpenProject::Reporting::SpecHelper::CustomFieldFilterHelper
 
       it "should create classes for custom fields that get added after starting the server" do
         custom_field
-        expect { class_name_for(custom_field).constantize }.not_to raise_error
+        expect { filter_class_name_string(custom_field).constantize }.not_to raise_error
       end
 
       it "should remove the custom field classes after it is deleted" do
         custom_field
-        class_name = class_name_for(custom_field)
+        class_name = filter_class_name_string(custom_field)
         delete_work_package_custom_field(custom_field)
-        expect { class_name_for(custom_field).constantize }.to raise_error NameError
+        expect { filter_class_name_string(custom_field).constantize }.to raise_error NameError
       end
 
       it "should provide the correct available values" do
         custom_field2.save
 
         clear_cache
-        ao = class_name_for(custom_field2).constantize.available_operators.map(&:name)
+        ao = filter_class_name_string(custom_field2).constantize.available_operators.map(&:name)
         CostQuery::Operator.null_operators.each do |o|
           expect(ao).to include o.name
         end
@@ -381,12 +380,12 @@ describe CostQuery, type: :model, reporting_query_helper: true do
         custom_field2.save
 
         update_work_package_custom_field("Database", field_format: "string")
-        ao = class_name_for(custom_field2).constantize.available_operators.map(&:name)
+        ao = filter_class_name_string(custom_field2).constantize.available_operators.map(&:name)
         CostQuery::Operator.string_operators.each do |o|
           expect(ao).to include o.name
         end
         update_work_package_custom_field("Database", field_format: "int")
-        ao = class_name_for(custom_field2).constantize.available_operators.map(&:name)
+        ao = filter_class_name_string(custom_field2).constantize.available_operators.map(&:name)
         CostQuery::Operator.integer_operators.each do |o|
           expect(ao).to include o.name
         end
@@ -395,13 +394,13 @@ describe CostQuery, type: :model, reporting_query_helper: true do
       it "includes custom fields classes in CustomFieldEntries.all" do
         custom_field
         expect(CostQuery::Filter::CustomFieldEntries.all).
-          to include(class_name_for(custom_field).constantize)
+          to include(filter_class_name_string(custom_field).constantize)
       end
 
       it "includes custom fields classes in Filter.all" do
         custom_field
         expect(CostQuery::Filter.all).
-          to include(class_name_for(custom_field).constantize)
+          to include(filter_class_name_string(custom_field).constantize)
       end
 
       def create_searchable_fields_and_values

--- a/spec/models/cost_query/group_by_spec.rb
+++ b/spec/models/cost_query/group_by_spec.rb
@@ -223,7 +223,7 @@ describe CostQuery, type: :model, reporting_query_helper: true do
       end
 
       def check_cache
-        CostReportsController.new.check_cache
+        CostQuery::Cache.reset!
         CostQuery::GroupBy::CustomFieldEntries.all
       end
 

--- a/spec/models/cost_query/group_by_spec.rb
+++ b/spec/models/cost_query/group_by_spec.rb
@@ -267,7 +267,7 @@ describe CostQuery, type: :model, reporting_query_helper: true do
         create_work_package_custom_field("AFreshCustomField")
         name = class_name_for('AFreshCustomField')
         delete_work_package_custom_field("AFreshCustomField")
-        expect(CostQuery::GroupBy.all).not_to include name.constantize
+        expect{name.constantize}.to raise_error NameError
       end
 
       it "includes custom fields classes in CustomFieldEntries.all" do

--- a/spec/requests/custom_field_cache_spec.rb
+++ b/spec/requests/custom_field_cache_spec.rb
@@ -45,13 +45,13 @@ describe 'Custom field filter and group by caching', type: :request do
   end
 
   def expect_group_by_all_to_not_exist(custom_field)
-    # can not check for whether the element is included in CostQuery::GroupBy if it does not exist
+    # can not check for whether the element is included in CostQuery::GroupBy.all if it does not exist
     expect { group_by_class_name_string(custom_field).constantize }.to raise_error NameError
   end
 
   def expect_filter_all_to_not_exist(custom_field)
-    # can not check for whether the element is included in CostQuery::GroupBy if it does not exist
-    expect { group_by_class_name_string(custom_field).constantize }.to raise_error NameError
+    # can not check for whether the element is included in CostQuery::Filter.all if it does not exist
+    expect { filter_class_name_string(custom_field).constantize }.to raise_error NameError
   end
 
   def visit_cost_reports_index

--- a/spec/requests/custom_field_cache_spec.rb
+++ b/spec/requests/custom_field_cache_spec.rb
@@ -1,0 +1,63 @@
+#-- copyright
+# OpenProject Reporting Plugin
+#
+# Copyright (C) 2010 - 2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#++
+
+require 'spec_helper'
+
+describe 'Custom field filter and group by caching', :type => :request do
+  let(:project) { FactoryGirl.create(:valid_project) }
+  let(:user) { FactoryGirl.create(:admin) }
+  let(:custom_field) { FactoryGirl.build(:work_package_custom_field) }
+  let(:custom_field2) { FactoryGirl.build(:work_package_custom_field) }
+
+  before do
+    allow(User).to receive(:current).and_return(user)
+
+    custom_field.save!
+  end
+
+  it 'removes the filter/group_by if the custom field is removed' do
+    custom_field2.save!
+
+    get "projects/#{project.id}/cost_reports"
+
+    expect(CostQuery::GroupBy.all).to include("CostQuery::GroupBy::CustomField#{custom_field.id}".constantize)
+    expect(CostQuery::GroupBy.all).to include("CostQuery::GroupBy::CustomField#{custom_field2.id}".constantize)
+
+    custom_field2.destroy
+
+    get "projects/#{project.id}/cost_reports"
+
+    expect(CostQuery::GroupBy.all).to include("CostQuery::GroupBy::CustomField#{custom_field.id}".constantize)
+    # can not check for whether the element is included in CostQuery::GroupBy if it does not exist
+    expect{"CostQuery::GroupBy::CustomField#{custom_field2.id}".constantize}.to raise_error NameError
+  end
+
+  it 'removes the filter/group_by if the last custom field is removed' do
+    get "projects/#{project.id}/cost_reports"
+
+    expect(CostQuery::GroupBy.all).to include("CostQuery::GroupBy::CustomField#{custom_field.id}".constantize)
+
+    custom_field.destroy
+
+    get "projects/#{project.id}/cost_reports"
+
+    # can not check for whether the element is included in CostQuery::GroupBy if it does not exist
+    expect{"CostQuery::GroupBy::CustomField#{custom_field.id}".constantize}.to raise_error NameError
+  end
+end

--- a/spec/support/configuration_helper.rb
+++ b/spec/support/configuration_helper.rb
@@ -18,17 +18,14 @@
 #++
 
 module OpenProject::Reporting::SpecHelper
-  module CustomFieldFilterHelper
-    def group_by_class_name_string(custom_field)
-      id = custom_field.is_a?(ActiveRecord::Base) ? custom_field.id : custom_field
-
-      "CostQuery::GroupBy::CustomField#{id}"
-    end
-
-    def filter_class_name_string(custom_field)
-      id = custom_field.is_a?(ActiveRecord::Base) ? custom_field.id : custom_field
-
-      "CostQuery::Filter::CustomField#{id}"
+  module ConfigurationHelper
+    def mock_cache_classes_setting_with(value)
+      allow(OpenProject::Configuration).to receive(:[]).and_call_original
+      allow(OpenProject::Configuration).to receive(:[])
+        .with('cost_reporting_cache_filter_classes')
+        .and_return(value)
+      allow(OpenProject::Configuration).to receive(:cost_reporting_cache_filter_classes)
+        .and_return(value)
     end
   end
 end

--- a/spec/support/custom_field_filter.rb
+++ b/spec/support/custom_field_filter.rb
@@ -1,0 +1,30 @@
+#-- copyright
+# OpenProject Reporting Plugin
+#
+# Copyright (C) 2010 - 2014 the OpenProject Foundation (OPF)
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# version 3.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#++
+
+module OpenProject::Reporting::SpecHelper
+  module CustomFieldFilterHelper
+    def group_by_class_name_string(custom_field)
+      "CostQuery::GroupBy::CustomField#{custom_field.id}"
+    end
+
+    def filter_class_name_string(custom_field)
+      "CostQuery::Filter::CustomField#{custom_field.id}"
+    end
+  end
+end


### PR DESCRIPTION
This addresses a couple of bugs:
- removes the bug that the filter/group_by for the last custom field would not be removed.
- removes all subclasses generated for a custom field. Formerly, the constant would no longer be referenced in `CostQuery::Filter.all` et al. but would still be present causing memory to be used up unnecessarily.

Additionally, it refactors the caching mechanism to be it's own class enhancing "separation of concerns" and testability.

Additionally, it introduces a configuration option to disable caching altogether as the probability for a tenant to hit the same DB twice is highly unlikely and caching in the way it is implemented right now will thus only slow down the response. 

Additionally, it refactors some specs to reduce duplication.

This should be all for https://community.openproject.org/work_packages/5344

**Notes**
- In one spec, OpenProject::Configuration is initialized with a blank configuration. This should be the default behaviour to avoid specs depending on the config/configuration.yml and being influenced by previous runs. 
- I patched OpenProject::Configuration to add a default value but there should be an API for that. 
