### PR TITLE
Fix/configuration patch applied to late

### DIFF
--- a/lib/open_project/reporting/patches/open_project/configuration_patch.rb
+++ b/lib/open_project/reporting/patches/open_project/configuration_patch.rb
@@ -24,7 +24,23 @@ module OpenProject::Reporting::Patches
   module OpenProject::ConfigurationPatch
     def self.included(base)
       base.class_eval do
+        extend ModuleMethods
+
         @defaults['cost_reporting_cache_filter_classes'] = true
+
+        if config_loaded_before_patch?
+          @config['cost_reporting_cache_filter_classes'] = true
+        end
+      end
+    end
+
+    module ModuleMethods
+      def config_loaded_before_patch?
+        @config.present? && !@config.has_key?('cost_reporting_cache_filter_classes')
+      end
+
+      def cost_reporting_cache_filter_classes
+        @config['cost_reporting_cache_filter_classes']
       end
     end
   end


### PR DESCRIPTION
Solves problems introduced in #68:
- In some configurations, plugins access OpenProject::Configuration before the patch here is applied. This leads to the configuration being read from file and everything being written to the `@config` variable. The patch then comes to late and used to only add a default value. But that value was never applied to the `@config` hash.
- The spec had some unwanted side effects leaving records in the db.

https://community.openproject.org/work_packages/5344
