### PR TITLE
Fix broken routes to Cost report due to url_for namespaces

### DIFF
--- a/lib/open_project/reporting/engine.rb
+++ b/lib/open_project/reporting/engine.rb
@@ -45,7 +45,7 @@ module OpenProject::Reporting
       end
 
       #menu extensions
-      menu :top_menu, :cost_reports_global, {controller: 'cost_reports', action: 'index', project_id: nil},
+      menu :top_menu, :cost_reports_global, {controller: '/cost_reports', action: 'index', project_id: nil},
         caption: :cost_reports_title,
         if: Proc.new {
           ( User.current.allowed_to?(:view_time_entries, nil, global: true) ||
@@ -56,7 +56,7 @@ module OpenProject::Reporting
         }
 
       menu :project_menu, :cost_reports,
-           {controller: 'cost_reports', action: 'index'},
+           {controller: '/cost_reports', action: 'index'},
            param: :project_id,
            after: :time_entries,
            caption: :cost_reports_title,


### PR DESCRIPTION
A spec concerned with that problem is `spec/features/menu_spec.rb`.
Within it, the correct solution is noted, but not applied to the menu items.

Depending on the current page the link to the cost reports was broken.
This seems to be due to a peculiarity of the rails routing where
`url_for controller: :foo` would return a link relative to the controller
handling the current request path if the controller was routed to via a
namespaced route.

Example:

`url_for controller: 'cost_reports'` will yield different results ...

when on `/projects/ponyo/work_packages`: `/projects/ponyo/cost_reports` (correct)
when on `/projects/ponyo/work_packages/calendar`: `/work_packages/cost_reports?project_id=ponyo`

This is only relevant for project menu entries, not global ones (`project_id` param is nil)*.
Meaning that you have to make sure to force the absolute URL in a project menu entry
by specificying the controller as e.g. '/cost_reports' instead of just 'cost_reports'.

Relevant work package: https://community.openproject.org/work_packages/20825
