### PR TITLE
Hide cost reports from anonymous users when authentication is required

### DIFF
--- a/lib/open_project/reporting/engine.rb
+++ b/lib/open_project/reporting/engine.rb
@@ -48,11 +48,13 @@ module OpenProject::Reporting
       menu :top_menu, :cost_reports_global, {controller: '/cost_reports', action: 'index', project_id: nil},
         caption: :cost_reports_title,
         if: Proc.new {
-          ( User.current.allowed_to?(:view_time_entries, nil, global: true) ||
-            User.current.allowed_to?(:view_own_time_entries, nil, global: true) ||
-            User.current.allowed_to?(:view_cost_entries, nil, global: true) ||
-            User.current.allowed_to?(:view_own_cost_entries, nil, global: true)
-          )
+          (User.current.logged? || !Setting.login_required?) &&
+            (
+              User.current.allowed_to?(:view_time_entries, nil, global: true) ||
+              User.current.allowed_to?(:view_own_time_entries, nil, global: true) ||
+              User.current.allowed_to?(:view_cost_entries, nil, global: true) ||
+              User.current.allowed_to?(:view_own_cost_entries, nil, global: true)
+            )
         }
 
       menu :project_menu, :cost_reports,


### PR DESCRIPTION
The module menu consolidation resulted in anonymous users being always
presented with the module menu, even when authentication is mandatory.

Core menu items were already changed to correct this behavior.

Relevant work package: https://community.openproject.org/work_packages/20935
