### PR TITLE
[23483] [5d] Tabelle mit ARIA-Rolle grid ausgezeichnet (Reporting)

### DIFF
--- a/lib/widget/entry_table.rb
+++ b/lib/widget/entry_table.rb
@@ -26,7 +26,6 @@ class Widget::Table::EntryTable < Widget::Table
     content = content_tag :div, class: 'generic-table--container -with-footer' do
       content_tag :div, class: 'generic-table--results-container' do
         table = content_tag :table, 'interactive-table' => true,
-                                    role: 'grid',
                                     class: 'generic-table',
                                     id: 'sortable-table' do
           concat colgroup


### PR DESCRIPTION
The role 'grid' should be used for interactive tables only. To avoid that blind users get confused the role was removed.

Core PR: https://github.com/opf/openproject/pull/4666

https://community.openproject.com/work_packages/23483/activity
