### PR TITLE
Fix: delete cost report

### DIFF
--- a/Gemfile.plugins
+++ b/Gemfile.plugins
@@ -1,7 +1,7 @@
 # Dependencies (need to be called before the actual gem)
 group :opf_plugins do
   gem "openproject-costs",           :git => "https://github.com/finnlabs/openproject-costs.git",         :branch => "dev"
-  gem "reporting_engine",            :git => "https://github.com/finnlabs/reporting_engine.git",          :branch => "dev"
+  gem "reporting_engine",            :git => "https://github.com/finnlabs/reporting_engine.git",          :branch => "fix/delete_cost_report"
 
   # Used by travis to bundle this plugin with the OpenProject core.
   # The tested plugin will be moved to the path `./plugins/this`

--- a/Gemfile.plugins
+++ b/Gemfile.plugins
@@ -1,6 +1,6 @@
 # Dependencies (need to be called before the actual gem)
 group :opf_plugins do
-  gem "openproject-costs",           :git => "https://github.com/finnlabs/openproject-costs.git",         :branch => "dev"
+  gem "openproject-costs",           :git => "https://github.com/finnlabs/openproject-costs.git",         :branch => "release/6.0"
   gem "reporting_engine",            :git => "https://github.com/finnlabs/reporting_engine.git",          :branch => "fix/delete_cost_report"
 
   # Used by travis to bundle this plugin with the OpenProject core.

--- a/app/controllers/cost_reports_controller.rb
+++ b/app/controllers/cost_reports_controller.rb
@@ -208,7 +208,7 @@ class CostReportsController < ApplicationController
       user.allowed_to?(:save_cost_reports, @project, options) or
         user.allowed_to?(:save_private_cost_reports, @project, options)
 
-    when :save, :delete, :rename
+    when :save, :destroy, :rename
       if report.is_public?
         user.allowed_to?(:save_cost_reports, @project, options)
       else

--- a/lib/open_project/reporting/engine.rb
+++ b/lib/open_project/reporting/engine.rb
@@ -28,7 +28,7 @@ module OpenProject::Reporting
              requires_openproject: '>= 4.0.0' do
 
       view_actions = [:index, :show, :drill_down, :available_values, :display_report_list]
-      edit_actions = [:create, :update, :rename, :delete]
+      edit_actions = [:create, :update, :rename, :destroy]
 
       #register reporting_module including permissions
       project_module :reporting_module do


### PR DESCRIPTION
WP [#23683](https://community.openproject.com/work_packages/23683/activity)

Depends on https://github.com/finnlabs/reporting_engine/pull/77.

The problem is that actually deleting the report checks permissions for the action `{ controller: :cost_reports, action: :destroy }` as per the normal rails method name for that action.
In the reporting engine, however, the check is made using `:delete` for the menu entry.
And only `:delete` was added to the necessary allowed actions for the `:save_private_cost_report` permission.

Another way to fix this would've been to just add both `:delete` and `:destroy`. But it's more consistent to check for the same everywhere.

**Note::** The 2nd commit is only to make the specs work. It points the reporting engine to the respective fix branch. Once this goes green, I will remove the commit.
