### PR TITLE
[23504] [2u] Inhalte aufgrund von Sonderzeichen schwer wahrnehmbar (Reporting)

### DIFF
--- a/app/models/cost_query/filter/user_id.rb
+++ b/app/models/cost_query/filter/user_id.rb
@@ -33,7 +33,7 @@ class CostQuery::Filter::UserId < Report::Filter::Base
                 .distinct
 
     values = users.map { |u| [u.name, u.id] }
-    values.unshift ["<< #{::I18n.t(:label_me)} >>", User.current.id.to_s] if User.current.logged?
+    values.unshift [::I18n.t(:label_me), User.current.id.to_s] if User.current.logged?
     values
   end
 end

--- a/features/links.feature
+++ b/features/links.feature
@@ -32,7 +32,6 @@ Feature: Cost Reporting Linkage
     And I send the query
 
     Then I should see "User"
-    # And I should see "<< me >>"
     # And I should see "me"
     And I should see "There is currently nothing to display."
     And I should not see "0.00"


### PR DESCRIPTION
This removes special characters from filter elements which were only used for styling issues. Blind users were confused by these characters.

https://community.openproject.com/work_packages/23504/activity

Related PRs:
- https://github.com/opf/openproject/pull/4722
- https://github.com/finnlabs/reporting_engine/pull/78
