### PR TITLE
[24430] Cursor not changed when hovering over sortable column in cost report

### DIFF
--- a/app/assets/stylesheets/reporting/reporting.css.sass
+++ b/app/assets/stylesheets/reporting/reporting.css.sass
@@ -8,6 +8,9 @@
   line-height: 1
   vertical-align: text-bottom
 
+.tablesorter-header
+  cursor: pointer
+
 .tablesorter-headerDesc .generic-table--sort-header span
   &:after
     @include sort-icons


### PR DESCRIPTION
This changes the cursor style for sortable header elements. Thus it indicates the user that the column is sortable.

https://community.openproject.com/projects/plugin-reporting/work_packages/24430/activity