### PR TITLE
[23469] Sort icons on cost reports table (Reporting)

### DIFF
--- a/app/assets/javascripts/reporting/reporting.js
+++ b/app/assets/javascripts/reporting/reporting.js
@@ -1,8 +1,17 @@
 //= require jquery-tablesorter
 
 (function($){
-
   $(document).ajaxComplete(function() {
+    // Override the default texts to enable translations
+    $.tablesorter.language = {
+          sortAsc      : I18n.t('js.sort.sorted_asc'),
+          sortDesc     : I18n.t('js.sort.sorted_dsc'),
+          sortNone     : I18n.t('js.sort.sorted_no'),
+          sortDisabled : I18n.t('js.sort.sorting_disabled'),
+          nextAsc      : I18n.t('js.sort.activate_asc'),
+          nextDesc     : I18n.t('js.sort.activate_dsc'),
+          nextNone     : I18n.t('js.sort.activate_no')
+    };
     $('#sortable-table').not('.tablesorter').tablesorter();
   });
 })(jQuery);


### PR DESCRIPTION
This overrides the default texts for the `aria-label` of the table header. Thus the sorting directions can be translated. There is an according core PR: https://github.com/opf/openproject/pull/5244

https://community.openproject.com/projects/telekom/work_packages/23469/activity