### PR TITLE
[24874] Two scrollbars displayed in cost report

### DIFF
--- a/app/assets/stylesheets/reporting/reporting.css.sass
+++ b/app/assets/stylesheets/reporting/reporting.css.sass
@@ -20,3 +20,9 @@
   &:after
     @include sort-icons
     content: "\e09f"
+
+#result-table .generic-table--results-container tfoot
+  td
+    width: 150px
+  .generic-table--footer-outer
+    width: inherit

--- a/lib/widget/entry_table.rb
+++ b/lib/widget/entry_table.rb
@@ -94,20 +94,20 @@ class Widget::Table::EntryTable < Widget::Table
     content_tag :tfoot do
       content_tag :tr do
         if show_result(@subject, 0) != show_result(@subject)
-          concat content_tag(:th, '', colspan: FIELDS.size)
-          concat content_tag(:th) {
+          concat content_tag(:td, '', colspan: FIELDS.size)
+          concat content_tag(:td) {
             concat content_tag(:div,
                                show_result(@subject),
                                class: 'inner generic-table--footer-outer')
           }
-          concat content_tag(:th) {
+          concat content_tag(:td) {
             concat content_tag(:div,
                                show_result(@subject, 0),
                                class: 'result generic-table--footer-outer')
           }
         else
-          concat content_tag(:th, '', colspan: FIELDS.size + 1)
-          concat content_tag(:th) {
+          concat content_tag(:td, '', colspan: FIELDS.size + 1)
+          concat content_tag(:td) {
             concat content_tag(:div,
                                show_result(@subject),
                                class: 'result generic-table--footer-outer')


### PR DESCRIPTION
This avoids doubled scrollbars in tables. This behavior occurred because the inner container shall be scrollable for the WP table (because of timelines).

According Core PR: https://github.com/opf/openproject/pull/5272

https://community.openproject.com/projects/openproject/work_packages/24874/activity