### PR TITLE
[24883] Table border missing for unsortable headers

### DIFF
--- a/lib/widget/entry_table.rb
+++ b/lib/widget/entry_table.rb
@@ -82,7 +82,9 @@ class Widget::Table::EntryTable < Widget::Table
         @subject.each_direct_result do |result|
           next if hit
           if entry_for(result).editable_by? User.current
-            concat content_tag(:th, class: 'unsortable') {}
+            concat content_tag(:th, class: 'unsortable') {
+              content_tag(:div, class: 'generic-table--empty-header')
+            }
             hit = true
           end
         end


### PR DESCRIPTION
This takes care that the border of the last table header column is shown again.

**According Core PR:** https://github.com/opf/openproject/pull/5273

https://community.openproject.com/projects/openproject/work_packages/24883/activity