### PR TITLE
[24883] Table border missing for unsortable headers (2)

### DIFF
--- a/lib/widget/entry_table.rb
+++ b/lib/widget/entry_table.rb
@@ -83,7 +83,7 @@ class Widget::Table::EntryTable < Widget::Table
           next if hit
           if entry_for(result).editable_by? User.current
             concat content_tag(:th, class: 'unsortable') {
-              content_tag(:div, class: 'generic-table--empty-header')
+              content_tag(:div, '', class: 'generic-table--empty-header')
             }
             hit = true
           end


### PR DESCRIPTION
This fixes a bug that causes a ruby hash to be displayed instead of the empty header.

https://community.openproject.com/projects/openproject/work_packages/24883/activity