### PR TITLE
[24919] Right part of cost report cut off on small screens

### DIFF
--- a/lib/widget/entry_table.rb
+++ b/lib/widget/entry_table.rb
@@ -33,9 +33,7 @@ class Widget::Table::EntryTable < Widget::Table
           concat foot
           concat body
         end
-        table +
-        content_tag(:div, class: 'generic-table--header-background') {} +
-        content_tag(:div, class: 'generic-table--footer-background') {}
+        table
       end
     end
     write content


### PR DESCRIPTION
This applies the new footer styling provided in https://github.com/opf/openproject/pull/5300. Thus the content is not cut off any more. 

https://community.openproject.com/projects/openproject/work_packages/24919/activity